### PR TITLE
Add empty dist folders to packages 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .DS_Store
 node_modules
-dist/
+/dist/
 
 # local env files
 .env.local

--- a/packages/tiptap-commands/dist/.gitignore
+++ b/packages/tiptap-commands/dist/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/packages/tiptap-extensions/dist/.gitignore
+++ b/packages/tiptap-extensions/dist/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/packages/tiptap-utils/dist/.gitignore
+++ b/packages/tiptap-utils/dist/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/packages/tiptap/dist/.gitignore
+++ b/packages/tiptap/dist/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Build:packages fails due to an issue with rollup not creating the folders automatically so I added them to the repo.