### PR TITLE
add init event

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ export default {
 | `editable` | `Boolean` | `true` | When set to `false` the editor is read-only. |
 | `doc` | `Object` | `null` | The editor state object used by Prosemirror. You can also pass HTML to the `content` slot. When used both, the `content` slot will be ignored. |
 | `extensions` | `Array` | `[]` | A list of extensions used, by the editor. This can be `Nodes`, `Marks` or `Plugins`. |
+| `@init` | `Object` | `undefined` | This will return an Object with the current `state` and `view` of Prosemirror on init. |
 | `@update` | `Object` | `undefined` | This will return an Object with the current `state` of Prosemirror, a `getJSON()` and `getHTML()` function on every change. |
 
 ## Scoped Slots

--- a/packages/tiptap/src/components/editor.js
+++ b/packages/tiptap/src/components/editor.js
@@ -100,6 +100,10 @@ export default {
 			this.view = this.createView()
 			this.commands = this.createCommands()
 			this.updateMenuActions()
+			this.$emit('init', {
+				view: this.view,
+				state: this.state,
+			})
 		},
 
 		createSchema() {


### PR DESCRIPTION
In order to use debug tool [prosemirror-dev-tools](https://github.com/d4rkr00t/prosemirror-dev-tools) we need access to ProseMirror view object. This PR add Editor component event `init` with this variable.