### PR TITLE
added windows support for build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
     "packages/*"
   ],
   "scripts": {
-    "start": "./node_modules/@babel/node/bin/babel-node.js build/examples/server.js --env=development",
-    "build:packages": "./node_modules/@babel/node/bin/babel-node.js build/packages/build.js",
-    "build:examples": "./node_modules/@babel/node/bin/babel-node.js build/examples/build.js --env=production",
+    "start": "node ./node_modules/@babel/node/bin/babel-node.js ./build/examples/server.js --env=development",
+    "build:packages": "node ./node_modules/@babel/node/bin/babel-node.js ./build/packages/build.js",
+    "build:examples": "node ./node_modules/@babel/node/bin/babel-node.js ./build/examples/build.js --env=production",
     "release": "yarn build:packages && lerna publish"
   },
   "babel": {


### PR DESCRIPTION
This let's me start the dev server under windows 10.
But I can't test this under macOS or linux currently.

This will fix #43 but without the need for cross-env as in #42 
