### PR TITLE
refactor(tiptap-extensions): Do not import the full `lowlight` library.

### DIFF
--- a/examples/Components/Routes/CodeHighlighting/examples.js
+++ b/examples/Components/Routes/CodeHighlighting/examples.js
@@ -26,3 +26,25 @@ body, .usertext {
     content: attr(href)
   }
 }`
+
+
+export const explicitImportExample = `import javascript from 'highlight.js/lib/languages/javascript'
+import { Editor } from 'tiptap'
+
+export default {
+  components: {
+    Editor
+  },
+  data() {
+    return {
+      extensions: [
+        new CodeBlockHighlightNode({
+          languages: {
+            javascript,
+            css
+          }
+        })
+      ]
+    }
+  }
+}`;

--- a/examples/Components/Routes/CodeHighlighting/index.vue
+++ b/examples/Components/Routes/CodeHighlighting/index.vue
@@ -9,8 +9,14 @@
 				<p>
 					These are code blocks with <strong>automatic syntax highlighting</strong> based on highlight.js.
 				</p>
-				<pre><code v-html="javascript"></code></pre>
-				<pre><code v-html="css"></code></pre>
+				<pre><code v-html="jsExample"></code></pre>
+				<pre><code v-html="cssExample"></code></pre>
+
+				<p>
+					Note: tiptap doesn't import syntax highlighting language definitions from highlight.js. You
+					<strong>must</strong> import them and initialize the extension with all languages you want to support:
+				</p>
+				<pre><code v-html="explicitImportExample"></code></pre>
 			</div>
 
 		</editor>
@@ -18,6 +24,9 @@
 </template>
 
 <script>
+import javascript from 'highlight.js/lib/languages/javascript'
+import css from 'highlight.js/lib/languages/css'
+
 import { Editor } from 'tiptap'
 import {
 	CodeBlockHighlightNode,
@@ -29,8 +38,9 @@ import {
 } from 'tiptap-extensions'
 
 import {
-	javascript,
-	css,
+	javascript as jsExample,
+	css as cssExample,
+	explicitImportExample
 } from './examples'
 
 export default {
@@ -40,15 +50,21 @@ export default {
 	data() {
 		return {
 			extensions: [
-				new CodeBlockHighlightNode(),
+				new CodeBlockHighlightNode({
+					languages: {
+						javascript,
+						css
+					}
+				}),
 				new HardBreakNode(),
 				new HeadingNode({ maxLevel: 3 }),
 				new BoldMark(),
 				new CodeMark(),
 				new ItalicMark(),
 			],
-			javascript,
-			css,
+			jsExample,
+			cssExample,
+			explicitImportExample,
 		}
 	},
 }

--- a/packages/tiptap-extensions/src/nodes/CodeBlockHighlight.js
+++ b/packages/tiptap-extensions/src/nodes/CodeBlockHighlight.js
@@ -2,7 +2,7 @@ import { Node, Plugin } from 'tiptap'
 import { Decoration, DecorationSet } from 'prosemirror-view'
 import { toggleBlockType, setBlockType, textblockTypeInputRule } from 'tiptap-commands'
 import { findBlockNodes } from 'prosemirror-utils'
-import low from 'lowlight'
+import low from 'lowlight/lib/core'
 
 function getDecorations(doc) {
 	const decorations = []
@@ -12,7 +12,7 @@ function getDecorations(doc) {
 
 	const flatten = list => list.reduce(
 		(a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), [],
-	)
+    )
 
 	function parseNodes(nodes, className = []) {
 		return nodes.map(node => {
@@ -62,6 +62,24 @@ function getDecorations(doc) {
 }
 
 export default class CodeBlockHighlightNode extends Node {
+
+    constructor(options = {}) {
+        super(options)
+        try {
+            Object.entries(this.options.languages).forEach(entry => {
+                const [name, mapping] = entry
+                low.registerLanguage(name, mapping)
+            })
+        } catch (err) {
+            throw new Error('Invalid syntax highlight definitions: define at least one highlight.js language mapping')
+        }
+    }
+
+    get defaultOptions() {
+        return {
+            languages: {},
+        }
+    }
 
 	get name() {
 		return 'code_block'


### PR DESCRIPTION
**BREAKING CHANGE**: `CodeBlockHighlight` was importing the full `lowlight` libraries, including _all_
syntax highlighting definitions from `highlight.js`. The new behavior changes the signature of
`CodeBlockHighlight` to accept an object with all syntax highlighting definitions. This means that
now the user of the library __MUST__ import languages themselves and tiptap will no longer
bundle the full `highlight.js` in itself.

---
### Testing: 

* Given that you have a working copy from the test repo[1]
* Run `npm run build` in the test repo and check if the highlight.js library is bundled with it.
* Checkout this branch and run `yarn build:packages`
* Copy[2] the contents of `tiptap-extensions` to the test repo:
  ```
  cp -R packages/tiptap-extensions /path/to/test/repo/node_modules/tiptap-extensions
  ```
* Run `npm run build` again on the rest repo
* You shouldn't see traces of `highlight.js` anymore.

*Expected result:*
<img width="1621" alt="screenshot 2018-10-13 at 16 11 20" src="https://user-images.githubusercontent.com/607262/46906581-0b3b7700-cf06-11e8-866c-95a590276621.png">

---

This closes #16 

[1] https://github.com/erickwilder/tiptap-treeshaking
[2] I had some issues with `npm link` and just to be quick I've copied the locally compiled `tiptap-extensions` over the files installed vie `npm install` in the test repo.